### PR TITLE
Add basic AI agency appointment site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+appointments.db

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# AI Integration Agency Demo
+
+This repository contains a minimal FastAPI application for scheduling appointments. The design aims for a sleek, high-tech feel inspired by IBM and Apple.
+
+## Features
+- Book appointments through a simple web form
+- View upcoming appointments
+- Backend implemented with FastAPI and SQLite
+
+## Running Locally
+
+Ensure Python 3.11+ is available. Install dependencies and start the server:
+
+```bash
+pip install fastapi uvicorn
+uvicorn app.main:app --reload
+```
+
+Then open `http://localhost:8000` in your browser.

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,35 @@
+import sqlite3
+from pathlib import Path
+
+DB_PATH = Path(__file__).resolve().parent / "appointments.db"
+
+CREATE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS appointments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    email TEXT NOT NULL,
+    datetime TEXT NOT NULL,
+    message TEXT
+)
+"""
+
+def init_db():
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(CREATE_TABLE_SQL)
+        conn.commit()
+
+def create_appointment(name: str, email: str, datetime: str, message: str):
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            "INSERT INTO appointments (name, email, datetime, message) VALUES (?, ?, ?, ?)",
+            (name, email, datetime, message),
+        )
+        conn.commit()
+
+def fetch_appointments():
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            "SELECT id, name, email, datetime, message FROM appointments ORDER BY datetime DESC"
+        ).fetchall()
+        return [dict(row) for row in rows]

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
-from fastapi import FastAPI, Request, Form
+from fastapi import FastAPI
+from pydantic import BaseModel
 from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
@@ -24,9 +25,21 @@ init_db()
 async def index():
     return FileResponse(BASE_DIR / "static" / "index.html")
 
+class AppointmentIn(BaseModel):
+    name: str
+    email: str
+    datetime: str
+    message: str | None = None
+
+
 @app.post("/api/appointments")
-async def create(name: str = Form(...), email: str = Form(...), datetime: str = Form(...), message: str = Form("")):
-    create_appointment(name, email, datetime, message)
+async def create(app_data: AppointmentIn):
+    create_appointment(
+        app_data.name,
+        app_data.email,
+        app_data.datetime,
+        app_data.message or "",
+    )
     return {"status": "created"}
 
 @app.get("/api/appointments")

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,34 @@
+from fastapi import FastAPI, Request, Form
+from fastapi.responses import FileResponse, HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.middleware.cors import CORSMiddleware
+from pathlib import Path
+
+from .db import init_db, create_appointment, fetch_appointments
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+app = FastAPI(title="AI Integration Agency")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.mount("/static", StaticFiles(directory=BASE_DIR / "static"), name="static")
+
+init_db()
+
+@app.get("/", response_class=HTMLResponse)
+async def index():
+    return FileResponse(BASE_DIR / "static" / "index.html")
+
+@app.post("/api/appointments")
+async def create(name: str = Form(...), email: str = Form(...), datetime: str = Form(...), message: str = Form("")):
+    create_appointment(name, email, datetime, message)
+    return {"status": "created"}
+
+@app.get("/api/appointments")
+async def list_appointments():
+    return fetch_appointments()

--- a/app/main.py
+++ b/app/main.py
@@ -23,7 +23,13 @@ init_db()
 
 @app.get("/", response_class=HTMLResponse)
 async def index():
-    return FileResponse(BASE_DIR / "static" / "index.html")
+    """Serve the landing page.
+
+    Using ``HTMLResponse`` ensures browsers display the page instead of
+    triggering a download when ``HEAD`` requests are made.
+    """
+    index_path = BASE_DIR / "static" / "index.html"
+    return HTMLResponse(index_path.read_text())
 
 class AppointmentIn(BaseModel):
     name: str

--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,21 @@
+async function loadAppointments() {
+    const res = await fetch('/api/appointments');
+    const data = await res.json();
+    const tbody = document.querySelector('#appointments tbody');
+    tbody.innerHTML = '';
+    data.forEach(app => {
+        const row = document.createElement('tr');
+        row.innerHTML = `<td>${app.name}</td><td>${app.email}</td><td>${app.datetime}</td><td>${app.message}</td>`;
+        tbody.appendChild(row);
+    });
+}
+
+document.getElementById('appointment-form').addEventListener('submit', async e => {
+    e.preventDefault();
+    const formData = new FormData(e.target);
+    await fetch('/api/appointments', { method: 'POST', body: formData });
+    e.target.reset();
+    loadAppointments();
+});
+
+window.addEventListener('DOMContentLoaded', loadAppointments);

--- a/static/app.js
+++ b/static/app.js
@@ -13,7 +13,12 @@ async function loadAppointments() {
 document.getElementById('appointment-form').addEventListener('submit', async e => {
     e.preventDefault();
     const formData = new FormData(e.target);
-    await fetch('/api/appointments', { method: 'POST', body: formData });
+    const payload = Object.fromEntries(formData.entries());
+    await fetch('/api/appointments', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+    });
     e.target.reset();
     loadAppointments();
 });

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="/static/style.css">
+    <title>AI Integration Agency</title>
+</head>
+<body>
+    <header>
+        <h1>AI Integration Agency</h1>
+        <p>Book an appointment to transform your business with AI.</p>
+    </header>
+    <main>
+        <section class="form-section">
+            <h2>Schedule Appointment</h2>
+            <form id="appointment-form">
+                <input type="text" name="name" placeholder="Your Name" required>
+                <input type="email" name="email" placeholder="Email" required>
+                <input type="datetime-local" name="datetime" required>
+                <textarea name="message" placeholder="Message"></textarea>
+                <button type="submit">Book</button>
+            </form>
+        </section>
+        <section class="list-section">
+            <h2>Upcoming Appointments</h2>
+            <table id="appointments">
+                <thead>
+                    <tr><th>Name</th><th>Email</th><th>Date</th><th>Message</th></tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </section>
+    </main>
+    <script src="/static/app.js"></script>
+</body>
+</html>

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,70 @@
+body {
+    margin: 0;
+    font-family: Arial, sans-serif;
+    background: #f5f5f7;
+    color: #111;
+}
+
+header {
+    background: #000;
+    color: #fff;
+    padding: 2rem;
+    text-align: center;
+}
+
+header h1 {
+    margin: 0;
+    font-size: 2.5rem;
+    letter-spacing: 0.05em;
+}
+
+main {
+    max-width: 900px;
+    margin: 2rem auto;
+    padding: 0 1rem;
+}
+
+form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+input, textarea {
+    padding: 0.75rem;
+    font-size: 1rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+button {
+    background: #0071e3;
+    color: #fff;
+    border: none;
+    padding: 0.75rem;
+    font-size: 1rem;
+    cursor: pointer;
+    border-radius: 4px;
+    transition: background 0.3s;
+}
+
+button:hover {
+    background: #005bb5;
+}
+
+.list-section table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1rem;
+}
+
+.list-section th, .list-section td {
+    border: 1px solid #ddd;
+    padding: 0.5rem;
+}
+
+.list-section th {
+    background: #000;
+    color: #fff;
+}
+


### PR DESCRIPTION
## Summary
- set up a FastAPI app with in-memory SQLite database
- provide minimal HTML/CSS/JS frontend for booking and viewing appointments
- document usage in README

## Testing
- `python -m py_compile app/*.py`
- ❌ `pip install flask sqlalchemy` (failed due to network restrictions)

------
https://chatgpt.com/codex/tasks/task_e_685481da96c8832c8d2ab0701c433a45